### PR TITLE
Handle extra fields: course / hdop / speed / vdop

### DIFF
--- a/src/createGpx.js
+++ b/src/createGpx.js
@@ -54,15 +54,24 @@ export default function createGpx(waypoints, options = {}) {
   const defaultSettings = {
     activityName: "Everyday I'm hustlin'",
     creator: 'Patrick Hooper',
+    courseKey: 'course',
     eleKey: 'elevation',
     extKey: 'extensions',
+    hdopKey: 'hdop',
     latKey: 'latitude',
     lonKey: 'longitude',
+    speedKey: 'speed',
     startTime: null,
     timeKey: 'time',
+    vdopKey: 'vdop',
   };
   const settings = Object.assign({}, defaultSettings, options);
-  const { activityName, creator, eleKey, extKey, latKey, lonKey, startTime, timeKey } = settings;
+  const {
+    activityName, courseKey, creator,
+    eleKey, extKey, hdopKey, latKey,
+    lonKey, speedKey, startTime,
+    timeKey, vdopKey,
+  } = settings;
 
   // Initialize the `<gpx>` element with some default attributes.
   const gpx = xmlBuilder
@@ -119,14 +128,26 @@ export default function createGpx(waypoints, options = {}) {
     }
 
     // For every waypoint, add a `<trkpt>` element with a `lat` and `lon` attribute to `<trkseg>`.
-    // `<ele>` and `<time>` elements are added if the point has a corresponding key for each (as
-    // defined by the `eleKey` and `timeKey` settings, respectively).
+    // Other elements (elevation, time, course, speed, hdop, vdop) are added if
+    // the point has a corresponding key for each (as defined by the `eleKey` etc settings)
     const trkpt = trkseg
       .ele('trkpt')
       .att('lat', point[latKey])
       .att('lon', point[lonKey]);
+    if ({}.hasOwnProperty.call(point, courseKey)) {
+      trkpt.ele('course', point[courseKey]);
+    }
     if ({}.hasOwnProperty.call(point, eleKey)) {
       trkpt.ele('ele', point[eleKey]);
+    }
+    if ({}.hasOwnProperty.call(point, hdopKey)) {
+      trkpt.ele('hdop', point[hdopKey]);
+    }
+    if ({}.hasOwnProperty.call(point, speedKey)) {
+      trkpt.ele('speed', point[speedKey]);
+    }
+    if ({}.hasOwnProperty.call(point, vdopKey)) {
+      trkpt.ele('vdop', point[vdopKey]);
     }
     if ({}.hasOwnProperty.call(point, timeKey)) {
       const pointTime = point[timeKey];

--- a/test/createGpx-test.js
+++ b/test/createGpx-test.js
@@ -229,13 +229,13 @@ describe('createGpx', () => {
     );
   });
 
-  it('should add `<trkpt>` elements without `<ele>` element if `speedKey` is not found', () => {
+  it('should add `<trkpt>` elements without `<speed>` element if `speedKey` is not found', () => {
     expect(createGpx(waypoints)).to.not.match(
       /<trkpt>[\s\S]*<speed>.*<\/speed>[\s\S]*<\/trkpt>/
     );
   });
 
-  it('should add `<trkpt>` elements without `<ele>` element if `vdopKey` is not found', () => {
+  it('should add `<trkpt>` elements without `<vdop>` element if `vdopKey` is not found', () => {
     expect(createGpx(waypoints)).to.not.match(
       /<trkpt>[\s\S]*<vdop>.*<\/vdop>[\s\S]*<\/trkpt>/
     );

--- a/test/createGpx-test.js
+++ b/test/createGpx-test.js
@@ -211,9 +211,33 @@ describe('createGpx', () => {
     expect(numMatchedWaypoints).to.equal(waypoints.length);
   });
 
+  it('should add `<trkpt>` elements without `<course>` element if `courseKey` is not found', () => {
+    expect(createGpx(waypoints)).to.not.match(
+      /<trkpt>[\s\S]*<course>.*<\/course>[\s\S]*<\/trkpt>/
+    );
+  });
+
   it('should add `<trkpt>` elements without `<ele>` element if `eleKey` is not found', () => {
     expect(createGpx(waypoints)).to.not.match(
       /<trkpt>[\s\S]*<ele>.*<\/ele>[\s\S]*<\/trkpt>/
+    );
+  });
+
+  it('should add `<trkpt>` elements without `<hdop>` element if `hdopKey` is not found', () => {
+    expect(createGpx(waypoints)).to.not.match(
+      /<trkpt>[\s\S]*<hdop>.*<\/hdop>[\s\S]*<\/trkpt>/
+    );
+  });
+
+  it('should add `<trkpt>` elements without `<ele>` element if `speedKey` is not found', () => {
+    expect(createGpx(waypoints)).to.not.match(
+      /<trkpt>[\s\S]*<speed>.*<\/speed>[\s\S]*<\/trkpt>/
+    );
+  });
+
+  it('should add `<trkpt>` elements without `<ele>` element if `vdopKey` is not found', () => {
+    expect(createGpx(waypoints)).to.not.match(
+      /<trkpt>[\s\S]*<vdop>.*<\/vdop>[\s\S]*<\/trkpt>/
     );
   });
 
@@ -234,11 +258,15 @@ describe('createGpx', () => {
     let numMatchedWaypoints = 0;
 
     waypointsWithAllFields.forEach((point) => {
-      const { latitude, longitude, elevation, time, extensions } = point;
+      const { course, latitude, longitude, elevation, hdop, speed, time, vdop, extensions } = point;
       const { atemp, hr, cad } = extensions;
       const regex = new RegExp(
         `<trkpt lat="${latitude}" lon="${longitude}">\\s*` +
+        `<course>${course}</course>\\s*` +
         `<ele>${elevation}</ele>\\s*` +
+        `<hdop>${hdop}</hdop>\\s*` +
+        `<speed>${speed}</speed>\\s*` +
+        `<vdop>${vdop}</vdop>\\s*` +
         `<time>${time instanceof Date ? time.toISOString() : time}</time>\\s*` +
         `<extensions>\\s*` +
         `<gpxtpx:TrackPointExtension>\\s*` +

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -30,10 +30,14 @@ export const waypointsWithCustomKeys = [
 
 export const waypointsWithAllFields = [
   {
+    course: 45,
     elevation: 0,
+    hdop: 0,
     latitude: 26.852673,
     longitude: -80.08024,
+    speed: 1,
     time: '2016-06-07T23:41:12.000Z',
+    vdop: 0,
     extensions: {
       atemp: 3,
       hr: 86,
@@ -41,10 +45,14 @@ export const waypointsWithAllFields = [
     },
   },
   {
+    course: 40,
     elevation: 0,
+    hdop: 5,
     latitude: 26.852741,
     longitude: -80.08037,
+    speed: 2,
     time: '2016-06-07T23:41:13.000Z',
+    vdop: 5,
     extensions: {
       atemp: 6,
       hr: 88,
@@ -52,10 +60,14 @@ export const waypointsWithAllFields = [
     },
   },
   {
+    course: 35,
     elevation: 0,
+    hdop: 0,
     latitude: 26.852758,
     longitude: -80.08039,
+    speed: 3,
     time: new Date('2016-06-07T23:41:14.000Z'),
+    vdop: 0,
     extensions: {
       atemp: 9,
       hr: 90,
@@ -63,10 +75,14 @@ export const waypointsWithAllFields = [
     },
   },
   {
+    course: 30,
     elevation: 0,
+    hdop: 5,
     latitude: 26.853183,
     longitude: -80.08047,
+    speed: 4,
     time: '2016-06-07T23:41:15.000Z',
+    vdop: 5,
     extensions: {
       atemp: 11,
       hr: 92,


### PR DESCRIPTION
Hi,

Thanks for this wonderful library! I'm currently working on a webapp to report issues while riding a bike (think "Waze" for bike): https://framagit.org/phyks/cyclassist. I am keeping locally in the webapp the history of positions of the users and wanted to let them export this as GPX traces. This lib is super convenient.

I have some extra fields which could be exported to the GPX trace, namely:
* course is the heading in degrees with respect to North.
* hdop is the horizontal accuracy.
* speed is the speed in meters/second.
* vdop is the vertical accuracy.

Here is a PR to support this extra fields and output them in the GPX. Thanks!

EDIT: It should be coming with proper test suite. I did not open an issue prior to this PR since this is quite a basic and straightforward change in my opinion.