### PR TITLE
Use the browser DOM API

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "README.md",
     "src"
   ],
+  "browser": {
+    "lib/shim-document.js": false
+  },
   "main": "lib/index.js",
   "jsnext:main": "es/index.js",
   "repository": {
@@ -51,7 +54,7 @@
   "dependencies": {
     "babel-runtime": "6.18.0",
     "loose-envify": "1.3.0",
-    "xmlbuilder": "8.2.2"
+    "xmldom": "^0.1.27"
   },
   "devDependencies": {
     "babel-cli": "6.18.0",

--- a/src/shim-document.js
+++ b/src/shim-document.js
@@ -1,0 +1,6 @@
+import { DOMImplementation, XMLSerializer as XMLSerializerShim } from 'xmldom';
+
+export let document = {};
+document.implementation = new DOMImplementation();
+
+export let XMLSerializer = XMLSerializerShim;

--- a/test/createGpx-test.js
+++ b/test/createGpx-test.js
@@ -199,7 +199,7 @@ describe('createGpx', () => {
 
     waypoints.forEach((point) => {
       const regex = new RegExp(
-        `<trkpt lat="${point.latitude}" lon="${point.longitude}">[\\s\\S]*</trkpt>`
+        `<trkpt lat="${point.latitude}" lon="${point.longitude}"/>`
       );
       const matches = gpx.match(regex);
 


### PR DESCRIPTION
Hi,

Here is a PR to drop the dependency on `xmlbuilder` and rely on the same API as provided by the browser to manipulate XML documents. This is a first draft, but I'd like to discuss it and get some feedback before going much further. Tests should be fine and output should be ok as of now.

## Why moving to the DOM API?

Actually, I'm using this library client-side, in the browser. The dependency on `xmlbuilder` meant this whole lib had to be included in my builds, which means adding about 40kb (8kb with GZIP) to my builds. I'd like to spare this space.

The browsers already have the necessary functions to manipulate XML documents and in browser there is no need to use any extra lib, so I used this API. It seems to be widely supported https://caniuse.com/#feat=xml-serializer.

Node does not offer such functions (:'() so I used a library when running server side, namely xmldom (https://github.com/jindw/xmldom) which seemed to be a good fit for this use case.


## What is changing from a user point of view?

Hopefully, nothing should change for a user. Tests are still passing. So far, the real differences are:

* Empty tags are not longer output as `<tag></tag>` but are collapsed as `<tag/>`. I don't think there should be any issue with it, but previous behavior might be recoverable server side quite easily if needed (not sure about the client side though).
* Output is no longer pretty printed. Not sure how important it is. Pretty printing of xml documents might be doable in a second step, using another tool or lib. If required to be pretty-printed, this could be done with a XSLT transform, but might be a bit tricky :/


## Bundling for the browser

I created a `lib/shim-document.js` file to fake the `document.implementation` and `XMLSerializer` APIs of the browser using `xmldom`. I used the `browser` key in `package.json` to bundle this file only in server mode and not when bundling for a client. This part is not tested so far though, but this gives the idea. :) This way, client will only fetch the `createGPX.js` file and no additionnal libs.

Thanks for any feedback on this!