### PR TITLE
Fix GPX attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For all your hard work, you'll be rewarded with GPX output in your console that 
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<gpx creator="Patrick Hooper" version="1.1" xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/GpxExtensions/v3 http://www.garmin.com/xmlschemas/GpxExtensionsv3.xsd http://www.garmin.com/xmlschemas/TrackPointExtension/v1 http://www.garmin.com/xmlschemas/TrackPointExtensionv1.xsd">
+<gpx creator="GPS to GPX (https://npm.im/gps-to-gpx)" version="1.1" xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/GpxExtensions/v3 http://www.garmin.com/xmlschemas/GpxExtensionsv3.xsd http://www.garmin.com/xmlschemas/TrackPointExtension/v1 http://www.garmin.com/xmlschemas/TrackPointExtensionv1.xsd">
   <metadata>
     <name>RUN</name>
     <time>2016-07-06T12:36:00Z</time>

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For all your hard work, you'll be rewarded with GPX output in your console that 
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<gpx creator="GPS to GPX (https://npm.im/gps-to-gpx)" version="1.1" xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/GpxExtensions/v3 http://www.garmin.com/xmlschemas/GpxExtensionsv3.xsd http://www.garmin.com/xmlschemas/TrackPointExtension/v1 http://www.garmin.com/xmlschemas/TrackPointExtensionv1.xsd">
+<gpx version="1.1" creator="GPS to GPX (https://npm.im/gps-to-gpx)" xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/GpxExtensions/v3 http://www.garmin.com/xmlschemas/GpxExtensionsv3.xsd http://www.garmin.com/xmlschemas/TrackPointExtension/v2 http://www.garmin.com/xmlschemas/TrackPointExtensionv2.xsd">
   <metadata>
     <name>RUN</name>
     <time>2016-07-06T12:36:00Z</time>

--- a/README.md
+++ b/README.md
@@ -121,6 +121,30 @@ createGpx(waypoints[, options])
 
 (*string*): A GPX (a form of XML) string composed of the given waypoints and options.
 
+## Extensions
+
+Some pieces of data do not map to an appropriate element in the official GPX 1.1 spec, such as speed. This data can be added via extensions. This library affords you the use of Garmin's track point extensions (`atemp`, `wtemp`, `depth`, `hr`, `cad`, `speed`, `course`, `bearing`). To use them, add an extensions object with keys named exactly as the track point extension(s) you want to use to the points in your waypoints array. So, for example, adding speed to the original JSON data from above might look like this:
+
+```json
+{
+  "activityType": "RUN",
+  "startTime": "2016-07-06T12:36:00Z",
+  "waypoints": [
+    {
+      "latitude": 26.852324,
+      "longitude": -80.08045,
+      "elevation": 0,
+      "time": "2016-07-06T12:36:00Z",
+      "extensions": {
+        "speed": 5
+      }
+    }
+  ]
+}
+```
+
+Note that we added an object called `extensions` to the waypoint. This is customizable via the `extKey` setting passed to the `createGpx` function; "extensions" is just the default value. Also note that we used a key literally called `speed` to match the exact name of the Garmin extension. This is _not_ customizable.
+
 ## Examples
 
 If you're not sure where to start with the GPS to GPX library, maybe the example(s) below can help:

--- a/src/createGpx.js
+++ b/src/createGpx.js
@@ -81,14 +81,16 @@ export default function createGpx(waypoints, options = {}) {
     .att('creator', creator)
     .att('version', '1.1')
     .att('xmlns', 'http://www.topografix.com/GPX/1/1')
+    .att('xmlns:gpxx', 'http://www.garmin.com/xmlschemas/GpxExtensions/v3')
+    .att('xmlns:gpxtpx', 'http://www.garmin.com/xmlschemas/TrackPointExtension/v2')
     .att('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance')
     .att('xsi:schemaLocation',
       'http://www.topografix.com/GPX/1/1 ' +
       'http://www.topografix.com/GPX/1/1/gpx.xsd ' +
       'http://www.garmin.com/xmlschemas/GpxExtensions/v3 ' +
       'http://www.garmin.com/xmlschemas/GpxExtensionsv3.xsd ' +
-      'http://www.garmin.com/xmlschemas/TrackPointExtension/v1 ' +
-      'http://www.garmin.com/xmlschemas/TrackPointExtensionv1.xsd'
+      'http://www.garmin.com/xmlschemas/TrackPointExtension/v2 ' +
+      'http://www.garmin.com/xmlschemas/TrackPointExtensionv2.xsd'
     );
 
   // Add a `<metadata>` element to `<gpx>`. `<metadata>` gets a nested `<name>` element, and a

--- a/src/createGpx.js
+++ b/src/createGpx.js
@@ -53,7 +53,7 @@ export default function createGpx(waypoints, options = {}) {
   // Define default settings and merge in any user-defined options that override the defaults.
   const defaultSettings = {
     activityName: 'Activity',
-    creator: 'Patrick Hooper',
+    creator: 'GPS to GPX (https://npm.im/gps-to-gpx)',
     courseKey: 'course',
     eleKey: 'elevation',
     extKey: 'extensions',

--- a/test/createGpx-test.js
+++ b/test/createGpx-test.js
@@ -90,7 +90,7 @@ describe('createGpx', () => {
   });
 
   it('should add a `<gpx>` element with the default `creator`', () => {
-    expect(createGpx(waypoints)).to.match(/<gpx.*creator="Patrick Hooper".*>[\s\S]*<\/gpx>/);
+    expect(createGpx(waypoints)).to.match(/<gpx.*creator="GPS to GPX \(https:\/\/npm.im\/gps-to-gpx\)".*>[\s\S]*<\/gpx>/);
   });
 
   it('should add a `<gpx>` element with the provided `creator`', () => {


### PR DESCRIPTION
This includes updating the default value of the `creator` attribute to be more informative and modifying the namespacing attributes used for Garmin extensions.